### PR TITLE
Update questions and insights page styling

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,7 @@ import { NoteManager } from "@/components/note-manager"
 import { AgentsView } from "@/components/agents-view"
 import { AgentQuestionsView } from "@/components/agent-questions-view"
 import { QuestionDetailView } from "@/components/question-detail-view"
+import { AnimatedHeader } from "@/components/animated-header"
 
 interface Message {
   id: string
@@ -1091,22 +1092,28 @@ export default function ChatPage() {
                 paddingRight: currentView === "calendar" || currentView === "agents" ? "10px" : "40px",
               }}
             >
-              <header className="border-b py-1.5 px-2.5 flex justify-between items-center">
+              <header className="border-b py-4 px-6 flex justify-between items-center">
                 <div className="flex items-center">
-                  {/* Update the header labels */}
-                  <h1 className="text-base font-semibold text-foreground">
-                    {currentView === "calendar" && "Insights"}
-                    {currentView === "settings" && "Settings"}
-                    {currentView === "storage" && "Notes"}
-                    {currentView === "agents" && "Questions"}
-                  </h1>
+                  {/* Enhanced animated headers */}
+                  {currentView === "calendar" && (
+                    <AnimatedHeader text="Insights" size="md" className="mb-0" />
+                  )}
+                  {currentView === "settings" && (
+                    <AnimatedHeader text="Settings" size="md" className="mb-0" />
+                  )}
+                  {currentView === "storage" && (
+                    <AnimatedHeader text="Notes" size="md" className="mb-0" />
+                  )}
+                  {currentView === "agents" && (
+                    <AnimatedHeader text="Questions" size="md" className="mb-0" />
+                  )}
                 </div>
               </header>
               <div className={`flex-1 overflow-auto flex items-start ${currentView === "calendar" || currentView === "agents" ? "" : "justify-center"}`}>
                 {currentView === "calendar" && <CalendarView className="w-full h-full" />}
                 {currentView === "settings" && <SettingsView className="w-full max-w-6xl mx-auto" />}
                 {currentView === "storage" && <StorageView className="w-full h-full" />}
-                {currentView === "agents" && <CalendarView className="w-full h-full" />}
+                {currentView === "agents" && <AgentsView className="w-full h-full" />}
               </div>
             </div>
           </div>

--- a/components/agents-view.tsx
+++ b/components/agents-view.tsx
@@ -3,6 +3,7 @@
 import { motion } from "framer-motion"
 import { HelpCircle, User, Bot, MessageSquare } from "lucide-react"
 import { cn } from "@/lib/utils"
+import { SectionHeader } from "@/components/section-header"
 
 interface AgentsViewProps {
   className?: string
@@ -19,9 +20,16 @@ interface QuestionCardData {
 function QuestionCard({ question, onClick }: { question: QuestionCardData; onClick: () => void }) {
   return (
     <motion.div
-      whileHover={{ scale: 1.02 }}
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, ease: "easeOut" }}
+      whileHover={{ 
+        scale: 1.02, 
+        boxShadow: "0 10px 30px rgba(var(--primary-rgb), 0.1)",
+        borderColor: "rgba(var(--primary-rgb), 0.3)"
+      }}
       whileTap={{ scale: 0.98 }}
-      className="bg-background/80 backdrop-blur-sm border border-primary/20 rounded-xl p-4 cursor-pointer hover:shadow-lg transition-all duration-300"
+      className="bg-background/80 backdrop-blur-sm border border-primary/20 rounded-xl p-4 cursor-pointer hover:shadow-lg transition-all duration-300 relative overflow-hidden group"
       onClick={onClick}
     >
       <div className="space-y-3">
@@ -38,9 +46,16 @@ function QuestionCard({ question, onClick }: { question: QuestionCardData; onCli
           </div>
           <MessageSquare className="h-4 w-4 text-primary/50" />
         </div>
-        <h3 className="text-sm font-medium text-foreground line-clamp-3">{question.question}</h3>
-        <p className="text-xs text-muted-foreground">Asked: {question.timestamp}</p>
+        <h3 className="text-sm font-medium text-foreground line-clamp-3 group-hover:text-primary/90 transition-colors duration-300">
+          {question.question}
+        </h3>
+        <p className="text-xs text-muted-foreground group-hover:text-muted-foreground/80 transition-colors duration-300">
+          Asked: {question.timestamp}
+        </p>
       </div>
+      
+      {/* Hover gradient overlay */}
+      <div className="absolute inset-0 bg-gradient-to-r from-primary/5 via-transparent to-primary/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none" />
     </motion.div>
   )
 }
@@ -119,9 +134,11 @@ export function AgentsView({ className }: AgentsViewProps) {
       <div className="grid grid-cols-2 gap-8 h-full p-6">
         {/* Left Half - Agent Questions */}
         <div className="space-y-6">
-          <div className="mb-6">
-            <h2 className="text-2xl font-bold text-foreground mb-2">Agent Questions</h2>
-          </div>
+          <SectionHeader 
+            text="Agent Questions" 
+            type="agent" 
+            variant="questions"
+          />
           
           <div className="grid grid-cols-1 gap-6">
             {agentQuestions.map((question) => (
@@ -132,9 +149,11 @@ export function AgentsView({ className }: AgentsViewProps) {
 
         {/* Right Half - User Questions */}
         <div className="space-y-6">
-          <div className="mb-6">
-            <h2 className="text-2xl font-bold text-foreground mb-2">User Questions</h2>
-          </div>
+          <SectionHeader 
+            text="User Questions" 
+            type="user" 
+            variant="questions"
+          />
           
           <div className="grid grid-cols-1 gap-6">
             {userQuestions.map((question) => (
@@ -144,8 +163,43 @@ export function AgentsView({ className }: AgentsViewProps) {
         </div>
       </div>
       
-      {/* Subtle Divider */}
-      <div className="absolute left-1/2 top-6 bottom-6 w-px bg-gradient-to-b from-transparent via-primary/20 to-transparent transform -translate-x-1/2"></div>
+      {/* Enhanced Divider with Animation */}
+      <motion.div
+        initial={{ scaleY: 0 }}
+        animate={{ scaleY: 1 }}
+        transition={{ duration: 0.8, delay: 0.5, ease: "easeInOut" }}
+        className="absolute left-1/2 top-6 bottom-6 w-px bg-gradient-to-b from-transparent via-primary/30 to-transparent transform -translate-x-1/2 origin-top"
+      >
+        {/* Animated orb in the middle */}
+        <motion.div
+          initial={{ scale: 0, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ duration: 0.6, delay: 1, ease: "easeOut" }}
+          className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-3 h-3 bg-primary/40 rounded-full blur-sm"
+        />
+        <motion.div
+          initial={{ scale: 0, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ duration: 0.6, delay: 1.1, ease: "easeOut" }}
+          className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-1.5 h-1.5 bg-primary rounded-full"
+        />
+      </motion.div>
+      
+      {/* Background decorative elements */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <motion.div
+          initial={{ opacity: 0, scale: 0.8 }}
+          animate={{ opacity: 0.03, scale: 1 }}
+          transition={{ duration: 2, delay: 0.5 }}
+          className="absolute top-10 left-10 w-32 h-32 bg-primary rounded-full blur-3xl"
+        />
+        <motion.div
+          initial={{ opacity: 0, scale: 0.8 }}
+          animate={{ opacity: 0.02, scale: 1 }}
+          transition={{ duration: 2, delay: 1 }}
+          className="absolute bottom-20 right-20 w-40 h-40 bg-primary rounded-full blur-3xl"
+        />
+      </div>
     </div>
   )
 }

--- a/components/animated-header.tsx
+++ b/components/animated-header.tsx
@@ -1,0 +1,71 @@
+"use client"
+
+import { motion } from "framer-motion"
+import { cn } from "@/lib/utils"
+
+interface AnimatedHeaderProps {
+  text: string
+  className?: string
+  size?: "sm" | "md" | "lg" | "xl"
+}
+
+export function AnimatedHeader({ text, className, size = "lg" }: AnimatedHeaderProps) {
+  const sizeClasses = {
+    sm: "text-lg",
+    md: "text-xl", 
+    lg: "text-2xl",
+    xl: "text-3xl"
+  }
+
+  const words = text.split(" ")
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: -20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.6, ease: "easeOut" }}
+      className={cn("relative", className)}
+    >
+      <h1 className={cn(
+        "font-bold text-foreground relative z-10",
+        sizeClasses[size]
+      )}>
+        {words.map((word, index) => (
+          <motion.span
+            key={`${word}-${index}`}
+            initial={{ opacity: 0, scale: 0.8 }}
+            animate={{ opacity: 1, scale: 1 }}
+            transition={{ 
+              duration: 0.5, 
+              delay: index * 0.1,
+              ease: "easeOut"
+            }}
+            className="colorful-word inline-block mr-2 last:mr-0"
+            style={{
+              display: "inline-block",
+              marginRight: index === words.length - 1 ? 0 : "0.25em"
+            }}
+          >
+            {word}
+          </motion.span>
+        ))}
+      </h1>
+      
+      {/* Subtle glow effect */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 0.3 }}
+        transition={{ duration: 1, delay: 0.5 }}
+        className="absolute inset-0 bg-gradient-to-r from-primary/10 via-primary/5 to-primary/10 rounded-lg blur-xl -z-10"
+      />
+      
+      {/* Animated underline */}
+      <motion.div
+        initial={{ scaleX: 0 }}
+        animate={{ scaleX: 1 }}
+        transition={{ duration: 0.8, delay: 0.3, ease: "easeInOut" }}
+        className="absolute bottom-0 left-0 right-0 h-0.5 bg-gradient-to-r from-transparent via-primary/60 to-transparent origin-center"
+      />
+    </motion.div>
+  )
+}

--- a/components/calendar-view.tsx
+++ b/components/calendar-view.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react"
 import { motion } from "framer-motion"
 import { cn } from "@/lib/utils"
+import { SectionHeader } from "@/components/section-header"
 
 interface CalendarViewProps {
   className?: string
@@ -21,19 +22,26 @@ interface KnowledgeCardData {
 function KnowledgeCard({ card, onClick }: { card: KnowledgeCardData; onClick: () => void }) {
   return (
     <motion.div
-      whileHover={{ scale: 1.02 }}
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, ease: "easeOut" }}
+      whileHover={{ 
+        scale: 1.02, 
+        boxShadow: "0 10px 30px rgba(var(--primary-rgb), 0.1)",
+        borderColor: "rgba(var(--primary-rgb), 0.3)"
+      }}
       whileTap={{ scale: 0.98 }}
-      className="bg-background/80 backdrop-blur-sm border border-primary/20 rounded-xl p-4 cursor-pointer hover:shadow-lg transition-all duration-300"
+      className="bg-background/80 backdrop-blur-sm border border-primary/20 rounded-xl p-4 cursor-pointer hover:shadow-lg transition-all duration-300 relative overflow-hidden group"
       onClick={onClick}
     >
       <div className="space-y-3">
         <div className="flex items-start justify-between">
-          <h3 className="text-lg font-semibold text-foreground line-clamp-2">{card.title}</h3>
+          <h3 className="text-lg font-semibold text-foreground line-clamp-2 group-hover:text-primary/90 transition-colors duration-300">{card.title}</h3>
           <span className="inline-block bg-primary/10 text-primary px-2 py-1 rounded-full text-xs font-medium shrink-0 ml-2">
             {card.category}
           </span>
         </div>
-        <p className="text-sm text-muted-foreground line-clamp-3">{card.content}</p>
+        <p className="text-sm text-muted-foreground line-clamp-3 group-hover:text-foreground/80 transition-colors duration-300">{card.content}</p>
         <div className="flex flex-wrap gap-1">
           {card.tags.slice(0, 3).map((tag, index) => (
             <span key={index} className="bg-muted text-muted-foreground px-2 py-1 rounded text-xs">
@@ -42,8 +50,13 @@ function KnowledgeCard({ card, onClick }: { card: KnowledgeCardData; onClick: ()
           ))}
           {card.tags.length > 3 && <span className="text-xs text-muted-foreground">+{card.tags.length - 3} more</span>}
         </div>
-        <p className="text-xs text-muted-foreground">Updated: {card.lastUpdated}</p>
+        <p className="text-xs text-muted-foreground group-hover:text-muted-foreground/80 transition-colors duration-300">
+          Updated: {card.lastUpdated}
+        </p>
       </div>
+      
+      {/* Hover gradient overlay */}
+      <div className="absolute inset-0 bg-gradient-to-r from-primary/5 via-transparent to-primary/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300 pointer-events-none" />
     </motion.div>
   )
 }
@@ -105,9 +118,11 @@ export function CalendarView({ className }: CalendarViewProps) {
       <div className="grid grid-cols-2 gap-8 h-full p-6">
         {/* Left Half - Agent Insights */}
         <div className="space-y-6">
-          <div className="mb-6">
-            <h2 className="text-2xl font-bold text-foreground mb-2">Agent Insights</h2>
-          </div>
+          <SectionHeader 
+            text="Agent Insights" 
+            type="agent" 
+            variant="insights"
+          />
           
           <div className="grid grid-cols-1 gap-6">
             {knowledgeCards.slice(0, Math.ceil(knowledgeCards.length / 2)).map((card) => (
@@ -118,9 +133,11 @@ export function CalendarView({ className }: CalendarViewProps) {
 
         {/* Right Half - User Insights */}
         <div className="space-y-6">
-          <div className="mb-6">
-            <h2 className="text-2xl font-bold text-foreground mb-2">User Insights</h2>
-          </div>
+          <SectionHeader 
+            text="User Insights" 
+            type="user" 
+            variant="insights"
+          />
           
           <div className="grid grid-cols-1 gap-6">
             {knowledgeCards.slice(Math.ceil(knowledgeCards.length / 2)).map((card) => (
@@ -130,8 +147,43 @@ export function CalendarView({ className }: CalendarViewProps) {
         </div>
       </div>
       
-      {/* Subtle Divider */}
-      <div className="absolute left-1/2 top-6 bottom-6 w-px bg-gradient-to-b from-transparent via-primary/20 to-transparent transform -translate-x-1/2"></div>
+      {/* Enhanced Divider with Animation */}
+      <motion.div
+        initial={{ scaleY: 0 }}
+        animate={{ scaleY: 1 }}
+        transition={{ duration: 0.8, delay: 0.5, ease: "easeInOut" }}
+        className="absolute left-1/2 top-6 bottom-6 w-px bg-gradient-to-b from-transparent via-primary/30 to-transparent transform -translate-x-1/2 origin-top"
+      >
+        {/* Animated orb in the middle */}
+        <motion.div
+          initial={{ scale: 0, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ duration: 0.6, delay: 1, ease: "easeOut" }}
+          className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-3 h-3 bg-primary/40 rounded-full blur-sm"
+        />
+        <motion.div
+          initial={{ scale: 0, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ duration: 0.6, delay: 1.1, ease: "easeOut" }}
+          className="absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-1.5 h-1.5 bg-primary rounded-full"
+        />
+      </motion.div>
+      
+      {/* Background decorative elements */}
+      <div className="absolute inset-0 overflow-hidden pointer-events-none">
+        <motion.div
+          initial={{ opacity: 0, scale: 0.8 }}
+          animate={{ opacity: 0.03, scale: 1 }}
+          transition={{ duration: 2, delay: 0.5 }}
+          className="absolute top-10 left-10 w-32 h-32 bg-primary rounded-full blur-3xl"
+        />
+        <motion.div
+          initial={{ opacity: 0, scale: 0.8 }}
+          animate={{ opacity: 0.02, scale: 1 }}
+          transition={{ duration: 2, delay: 1 }}
+          className="absolute bottom-20 right-20 w-40 h-40 bg-primary rounded-full blur-3xl"
+        />
+      </div>
 
       {selectedCard && (
         <motion.div

--- a/components/section-header.tsx
+++ b/components/section-header.tsx
@@ -1,0 +1,86 @@
+"use client"
+
+import { motion } from "framer-motion"
+import { cn } from "@/lib/utils"
+import { Bot, User, Sparkles, Brain } from "lucide-react"
+
+interface SectionHeaderProps {
+  text: string
+  type: "agent" | "user"
+  variant: "questions" | "insights"
+  className?: string
+}
+
+export function SectionHeader({ text, type, variant, className }: SectionHeaderProps) {
+  const Icon = type === "agent" ? Bot : User
+  const AccentIcon = variant === "questions" ? Sparkles : Brain
+  
+  const words = text.split(" ")
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: type === "agent" ? -30 : 30 }}
+      animate={{ opacity: 1, x: 0 }}
+      transition={{ duration: 0.6, ease: "easeOut" }}
+      className={cn("relative mb-6", className)}
+    >
+      <div className="flex items-center gap-3 mb-2">
+        <motion.div
+          initial={{ scale: 0, rotate: -180 }}
+          animate={{ scale: 1, rotate: 0 }}
+          transition={{ duration: 0.5, delay: 0.2, ease: "easeOut" }}
+          className={cn(
+            "p-2 rounded-full border-2 border-primary/20 bg-background/80 backdrop-blur-sm",
+            type === "agent" ? "text-primary" : "text-primary/80"
+          )}
+        >
+          <Icon className="h-5 w-5" />
+        </motion.div>
+        
+        <motion.div
+          initial={{ scale: 0 }}
+          animate={{ scale: 1 }}
+          transition={{ duration: 0.4, delay: 0.4, ease: "easeOut" }}
+          className="text-primary/60"
+        >
+          <AccentIcon className="h-4 w-4" />
+        </motion.div>
+      </div>
+
+      <h2 className="text-2xl font-bold text-foreground relative">
+        {words.map((word, index) => (
+          <motion.span
+            key={`${word}-${index}`}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ 
+              duration: 0.4, 
+              delay: 0.3 + (index * 0.1),
+              ease: "easeOut"
+            }}
+            className="colorful-word inline-block mr-2 last:mr-0"
+            style={{
+              display: "inline-block",
+              marginRight: index === words.length - 1 ? 0 : "0.25em"
+            }}
+          >
+            {word}
+          </motion.span>
+        ))}
+      </h2>
+      
+      {/* Decorative line */}
+      <motion.div
+        initial={{ scaleX: 0 }}
+        animate={{ scaleX: 1 }}
+        transition={{ duration: 0.6, delay: 0.5, ease: "easeInOut" }}
+        className={cn(
+          "mt-2 h-px bg-gradient-to-r origin-left",
+          type === "agent" 
+            ? "from-primary/40 via-primary/20 to-transparent" 
+            : "from-transparent via-primary/20 to-primary/40"
+        )}
+      />
+    </motion.div>
+  )
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Enhance "Questions" and "Insights" pages with animated headers and visual improvements to meet user request for a modern, sleek, and visually engaging interface.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The user requested to make the text headers and overall page presentation "pop more" with animations and a clean, modern aesthetic, adhering to the existing white and red theme. This PR introduces reusable animated header components and applies consistent styling across both pages, along with fixing a routing issue that prevented the correct "Questions" page from being displayed.

---
<a href="https://cursor.com/background-agent?bcId=bc-b951e209-fccb-488d-aa30-464e6797980a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b951e209-fccb-488d-aa30-464e6797980a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>